### PR TITLE
Update tokio to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,11 @@ futures-core = "0.3.5"
 futures-io = "0.3.5"
 once_cell = "1.4.1"
 pin-project-lite = "0.2"
-tokio = { version = "0.2", default-features = false, features = ["rt-core"] }
-tokio03 = { package = "tokio", version = "0.3", default-features = false, features = ["rt"] }
+tokio = { version = "1", default-features = false, features = ["rt"] }
 
 [dev-dependencies]
 blocking = "1"
 futures = "0.3.5"
-reqwest = "0.10.8"
-tokio = { version = "0.2", default-features = false, features = ["rt-core", "io-std", "io-util", "macros", "udp", "dns"] }
-warp = "0.2.4"
+reqwest = "0.11"
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "io-std", "io-util", "macros", "net", "time"] }
+warp = "0.3"


### PR DESCRIPTION
Closes #4

Note:

- this is a breaking change 
- this drops support for tokio 0.2/0.3 
- ~~ecosystem is still using tokio 0.2, so some examples are currently disabled~~