### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/smol-rs/async-compat"
 documentation = "https://docs.rs/async-compat"
 keywords = ["tokio", "futures", "convert", "context"]
 categories = ["asynchronous"]
-readme = "README.md"
 
 [dependencies]
 futures-core = "0.3.5"


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.