### PR TITLE
v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.2.3
+
+- Enter the `tokio` context while dropping wrapped `tokio` types. (#22)
+
 # Version 0.2.2
 
 - Add `smol-rs` logo to the docs. (#19)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-compat"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v0.x.y" git tag
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 description = "Compatibility adapter between tokio and futures"


### PR DESCRIPTION
- Enter the `tokio` context while dropping wrapped `tokio` types. (#22)