### PR TITLE
v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.2.4
+
+- Derive `Clone` for `Compat`. (#27)
+- Rather than spawning our own `tokio` runtime all of the time, reuse an
+  existing runtime if possible. (#30)
+
 # Version 0.2.3
 
 - Enter the `tokio` context while dropping wrapped `tokio` types. (#22)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-compat"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v0.x.y" git tag
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 description = "Compatibility adapter between tokio and futures"


### PR DESCRIPTION
- Derive `Clone` for `Compat`. (#27)
- Rather than spawning our own `tokio` runtime all of the time, reuse an
  existing runtime if possible. (#30)