### PR TITLE
Fix clippy::doc_lazy_continuation warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!       only means the future sets a thread-local variable pointing to the global tokio runtime so
 //!       that tokio's types can be used inside it.
 //! 2. Tokio and futures have similar but different I/O traits `AsyncRead`, `AsyncWrite`,
-//!   `AsyncBufRead`, and `AsyncSeek`.
+//!    `AsyncBufRead`, and `AsyncSeek`.
 //!     - Solution: When the [`Compat`] adapter is applied to an I/O type, it will implement traits
 //!       of the opposite kind. That's how you can use tokio-based types wherever futures-based
 //!       types are expected, and the other way around.


### PR DESCRIPTION
```
error: doc list item without indentation
  --> src/lib.rs:13:5
   |
13 | //!   `AsyncBufRead`, and `AsyncSeek`.
   |     ^^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
   = note: `-D clippy::doc-lazy-continuation` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::doc_lazy_continuation)]`
help: indent this line
   |
13 | //!    `AsyncBufRead`, and `AsyncSeek`.
   |       +
```