### PR TITLE
Exposes tokio guard API (Fixes #34)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ use std::thread;
 use futures_core::ready;
 use once_cell::sync::Lazy;
 use pin_project_lite::pin_project;
+use tokio::runtime::EnterGuard;
 
 /// Applies the [`Compat`] adapter to futures and I/O types.
 pub trait CompatExt {
@@ -451,6 +452,10 @@ impl<T: futures_io::AsyncSeek> tokio::io::AsyncSeek for Compat<T> {
         *self.as_mut().project().seek_pos = None;
         Poll::Ready(res)
     }
+}
+
+pub fn enter_tokio_runtime() -> EnterGuard<'static> {
+    TOKIO1.handle.enter()
 }
 
 static TOKIO1: Lazy<GlobalRuntime> = Lazy::new(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,9 @@ impl<T: futures_io::AsyncSeek> tokio::io::AsyncSeek for Compat<T> {
     }
 }
 
+/// Wrapper around the [`EnterGuard`] type.
+pub struct TokioRuntimeGuard(EnterGuard<'static>);
+
 /// Manually enter the tokio runtime.
 ///
 /// This function returns the [`EnterGuard`] which keeps the tokio runtime active until it is
@@ -461,8 +464,8 @@ impl<T: futures_io::AsyncSeek> tokio::io::AsyncSeek for Compat<T> {
 /// provides.
 ///
 /// TODO: Examples
-pub fn enter_tokio_runtime() -> EnterGuard<'static> {
-    get_runtime_handle().enter()
+pub fn enter_tokio_runtime() -> TokioRuntimeGuard {
+    TokioRuntimeGuard(get_runtime_handle().enter())
 }
 
 fn get_runtime_handle() -> tokio::runtime::Handle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,13 @@ impl<T: futures_io::AsyncSeek> tokio::io::AsyncSeek for Compat<T> {
     }
 }
 
+/// Manually enter the tokio runtime.
+///
+/// This function returns the [`EnterGuard`] which keeps the tokio runtime active until it is
+/// dropped. Use this function when you cannot use one of the preexisting wrappers this crate
+/// provides.
+///
+/// TODO: Examples
 pub fn enter_tokio_runtime() -> EnterGuard<'static> {
     TOKIO1.handle.enter()
 }


### PR DESCRIPTION
This PR adds a new function which wraps `TOKIO1.handle.enter()` and fixes #34 

I'm not quite sure how to write a good example for its documentation though.