### PR TITLE
v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.2.5
+
+- Fix a bug where the `tokio` runtime would disappear. (#38)
+
 # Version 0.2.4
 
 - Derive `Clone` for `Compat`. (#27)


### PR DESCRIPTION
- Fix a bug where the `tokio` runtime would disappear. (#38)
