### PR TITLE
ci: Use reusable workflows for clippy & Add MSRV check & Migrate to Rust 2021

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ defaults:
 jobs:
   fmt:
     uses: smol-rs/.github/.github/workflows/fmt.yml@main
+  clippy:
+    uses: smol-rs/.github/.github/workflows/clippy.yml@main
   security_audit:
     uses: smol-rs/.github/.github/workflows/security_audit.yml@main
     permissions:
@@ -52,11 +54,3 @@ jobs:
         if: startsWith(matrix.rust, 'nightly')
         run: cargo check -Z features=dev_dep
       - run: cargo test
-
-  clippy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update stable
-      - run: cargo clippy --all-features --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,11 @@ jobs:
         if: startsWith(matrix.rust, 'nightly')
         run: cargo check -Z features=dev_dep
       - run: cargo test
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack build --rust-version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ name = "async-compat"
 version = "0.2.5"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
+rust-version = "1.70"
 description = "Compatibility adapter between tokio and futures"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/async-compat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "async-compat"
 # - Create "v0.x.y" git tag
 version = "0.2.5"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Compatibility adapter between tokio and futures"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/async-compat"


### PR DESCRIPTION
See https://github.com/smol-rs/.github/pull/2 for details on reusable workflows.